### PR TITLE
made text container stay on top if on mobile

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -79,7 +79,10 @@ ul {
 /* homegrown functional CSS framework */
 
 .flex { display: flex !important; }
-.flex-wrap { flex-wrap: wrap !important; }
+.flex-wrap { flex-wrap: wrap-reverse; }
+
+div.flex-wrap { flex-wrap: nowrap; }
+
 .items-center { align-items: center !important; }
 .justify-around { justify-content: space-around !important; }
 


### PR DESCRIPTION
This fix changes the flex direction so that the text container stays on top (and still looks good) on smaller screens.

Before:
![image](https://user-images.githubusercontent.com/92005775/169929044-83444aa1-e728-4fcd-a129-f3260ddc893c.png)

Note the overlap of the grid and the header text that should be at the top of the page. This view is also after scrolling relatively far since the whole grid is sitting on top. 

After:
![image](https://user-images.githubusercontent.com/92005775/169929178-2a2bb5a8-c6e1-4114-8667-611d80f10cc9.png)

These two images are at the same screen size (367 x 868). This view is not scrolled down at all. Note also that the "legend" text describing what the boxes mean now sit next to the boxes rather than on top of them.